### PR TITLE
아이템 컨트롤러를 새로고침할 수 있는 기능을 추가합니다.

### DIFF
--- a/ImageViewer/Source/GalleryViewController.swift
+++ b/ImageViewer/Source/GalleryViewController.swift
@@ -487,6 +487,12 @@ open class GalleryViewController: UIPageViewController, ItemControllerDelegate {
         }
     }
 
+    /// 현재 페이지를 새로고침합니다.
+    open func refresh() {
+        let imageViewController = self.pagingDataSource.createItemController(currentIndex)
+        setViewControllers([imageViewController], direction: .forward, animated: false)
+    }
+
     func removePage(atIndex index: Int, completion: @escaping () -> Void) {
 
         // If removing last item, go back, otherwise, go forward


### PR DESCRIPTION
### 목적
GalleryItem이 변경되었을 경우에는 아이템 컨트롤러를 갱신할 수 있는 방법이 없습니다.
그래서 새로 아이템 컨트롤러를 만들 수 있는 기능을 추가합니다.

### 구현
필요한 기능만 제한적으로 구현했습니다.
현재 페이지`currentIndex`만 새로 컨트롤러를 만들어서 애니메이션 없이 갱신합니다.
